### PR TITLE
Update zmq_utils.h

### DIFF
--- a/include/zmq_utils.h
+++ b/include/zmq_utils.h
@@ -29,4 +29,8 @@
 
 /*  This file is deprecated, and all its functionality provided by zmq.h     */
 
-#warning zmq_utils.h is deprecated. All its functionality is provided by zmq.h.
+#ifndef _MSC_VER
+#warning(zmq_utils.h is deprecated.All its functionality is provided by zmq.h.)
+#else
+#pragma message("Warning: zmq_utils.h is deprecated. All its functionality is provided by zmq.h.")
+#endif


### PR DESCRIPTION
Previous change breaks MSVC compilation as #warning is not supported by MSVC
